### PR TITLE
add handlers to simulate LD client-side stream

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   disable:
     - funlen # allow long/complex functions for now
     - gocognit # allow long/complex functions for now
+    - goconst
     - gomnd # extremely aggressive linter that complains about all numeric literals, even just adding 1 to something (https://github.com/tommy-muehle/go-mnd)
     - wsl # enforces a very specific style with an idiosyncratic definition of what "cuddling" is
   fast: false

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,6 +37,14 @@
   version = "v1.5.1"
 
 [[projects]]
+  digest = "1:797d10f97b03b3580492b34e3a1cb2608a1d905307a002341e4b957c1b92d0ab"
+  name = "gopkg.in/launchdarkly/go-sdk-common.v1"
+  packages = ["ldvalue"]
+  pruneopts = "UT"
+  revision = "d48d1b4f4e7043144f7344be8a94cb3e3cd84275"
+  version = "1.0.0"
+
+[[projects]]
   digest = "1:55b110c99c5fdc4f14930747326acce56b52cfce60b24b1c03ef686ac0e46bb1"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -51,6 +59,7 @@
     "github.com/launchdarkly/eventsource",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/httphelpers/handlers_test.go
+++ b/httphelpers/handlers_test.go
@@ -70,6 +70,27 @@ func TestHandlerForPath(t *testing.T) {
 	assert.Equal(t, 404, rr3.Code)
 }
 
+func TestHandlerForPathRegex(t *testing.T) {
+	h1 := HandlerWithStatus(200)
+	h2 := HandlerWithStatus(304)
+	hp := HandlerForPathRegex("^/path[12]$", h1, h2)
+
+	rr1 := httptest.NewRecorder()
+	req1, _ := http.NewRequest("GET", "/path1", nil)
+	hp.ServeHTTP(rr1, req1)
+	assert.Equal(t, 200, rr1.Code)
+
+	rr2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("GET", "/path2", nil)
+	hp.ServeHTTP(rr2, req2)
+	assert.Equal(t, 200, rr2.Code)
+
+	rr3 := httptest.NewRecorder()
+	req3, _ := http.NewRequest("GET", "/path3", nil)
+	hp.ServeHTTP(rr3, req3)
+	assert.Equal(t, 304, rr3.Code)
+}
+
 func TestHandlerWithJSONResponse(t *testing.T) {
 	jsonObject := map[string]string{"things": "stuff"}
 	headers := make(http.Header)

--- a/ldservices/client_sdk_data.go
+++ b/ldservices/client_sdk_data.go
@@ -50,9 +50,9 @@ func (f FlagValueData) Data() string {
 // ClientSDKData is a set of flag value data as provided by the client-side SDK endpoints.
 //
 // It also implements the eventsource.Event interface, simulating a "put" event for the streaming service.
-type ClientSDKData map[string]flagValueDataJson
+type ClientSDKData map[string]flagValueDataJSON
 
-type flagValueDataJson struct {
+type flagValueDataJSON struct {
 	Version              int            `json:"version"`
 	FlagVersion          int            `json:"flagVersion"`
 	Value                ldvalue.Value  `json:"value"`
@@ -73,7 +73,7 @@ func NewClientSDKData() ClientSDKData {
 func (c ClientSDKData) Flags(flags ...FlagValueData) ClientSDKData {
 	for _, flag := range flags {
 		f := flag
-		d := flagValueDataJson{
+		d := flagValueDataJSON{
 			Version:     f.Version,
 			FlagVersion: f.FlagVersion,
 			Value:       f.Value,

--- a/ldservices/client_sdk_data.go
+++ b/ldservices/client_sdk_data.go
@@ -1,0 +1,118 @@
+package ldservices
+
+import (
+	"encoding/json"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+)
+
+// FlagValueData corresponds to the representation used by the client-side SDK endpoints.
+//
+// It also implements the eventsource.Event interface, simulating a "patch" event for the streaming service.
+type FlagValueData struct {
+	// Key is the flag key.
+	Key string
+	// Version is the flag version, as defined in the server-side SDK endpoints.
+	Version int
+	// FlagVersion is another version property that is provided only by client-side endpoints.
+	FlagVersion int
+	// Value is the variation value for the current user.
+	Value ldvalue.Value
+	// VariationIndex is the variation index for the current user. Use -1 to omit this.
+	VariationIndex int
+	// Reason is the evaluation reason, if available.
+	Reason ldreason.EvaluationReason
+	// TrackEvents is true if full event tracking is enabled for this flag.
+	TrackEvents bool
+	// DebugEventsUntilDate is the time, if any, until which debugging is enabled for this flag.
+	DebugEventsUntilDate ldtime.UnixMillisecondTime
+}
+
+// Id is for the eventsource.Event interface.
+func (f FlagValueData) Id() string { //nolint // standard capitalization would be ID(), but we didn't define this interface
+	return ""
+}
+
+// Event is for the eventsource.Event interface. It returns "patch".
+func (f FlagValueData) Event() string {
+	return "put"
+}
+
+// Data is for the eventsource.Event interface. It provides the marshalled data in the format used by the streaming
+// service.
+func (f FlagValueData) Data() string {
+	bytes, _ := json.Marshal(f)
+	return string(bytes)
+}
+
+// ClientSDKData is a set of flag value data as provided by the client-side SDK endpoints.
+//
+// It also implements the eventsource.Event interface, simulating a "put" event for the streaming service.
+type ClientSDKData map[string]flagValueDataJson
+
+type flagValueDataJson struct {
+	Version              int                         `json:"version"`
+	FlagVersion          int                         `json:"flagVersion"`
+	Value                ldvalue.Value               `json:"value"`
+	VariationIndex       *int                        `json:"variation,omitempty"`
+	Reason               *ldreason.EvaluationReason  `json:"reason,omitempty"`
+	TrackEvents          *bool                       `json:"trackEvents,omitempty"`
+	DebugEventsUntilDate *ldtime.UnixMillisecondTime `json:"debugEventsUntilDate,omitempty"`
+}
+
+// NewClientSDKData creates a ClientSDKData instance.
+//
+// This constructor is provided in case we ever change the implementation to be something other than just a map.
+func NewClientSDKData() ClientSDKData {
+	return make(ClientSDKData)
+}
+
+// Flags adds the specified items to the flags map.
+func (c ClientSDKData) Flags(flags ...FlagValueData) ClientSDKData {
+	for _, flag := range flags {
+		f := flag
+		d := flagValueDataJson{
+			Version:     f.Version,
+			FlagVersion: f.FlagVersion,
+			Value:       f.Value,
+		}
+		if f.VariationIndex >= 0 {
+			d.VariationIndex = &f.VariationIndex
+		}
+		if f.Reason.GetKind() != "" {
+			d.Reason = &f.Reason
+		}
+		if f.TrackEvents {
+			d.TrackEvents = &f.TrackEvents
+		}
+		if f.DebugEventsUntilDate > 0 {
+			d.DebugEventsUntilDate = &f.DebugEventsUntilDate
+		}
+		c[f.Key] = d
+	}
+	return c
+}
+
+// String returns the JSON encoding of the struct as a string.
+func (c ClientSDKData) String() string {
+	bytes, _ := json.Marshal(c)
+	return string(bytes)
+}
+
+// Id is for the eventsource.Event interface.
+func (c ClientSDKData) Id() string { //nolint // standard capitalization would be ID(), but we didn't define this interface
+	return ""
+}
+
+// Event is for the eventsource.Event interface. It returns "put".
+func (c ClientSDKData) Event() string {
+	return "put"
+}
+
+// Data is for the eventsource.Event interface. It provides the marshalled data in the format used by the streaming
+// service.
+func (c ClientSDKData) Data() string {
+	return c.String()
+}

--- a/ldservices/client_sdk_data_test.go
+++ b/ldservices/client_sdk_data_test.go
@@ -1,0 +1,62 @@
+package ldservices
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyClientSDKData(t *testing.T) {
+	expectedJSON := `{}`
+	data := NewClientSDKData()
+	bytes, err := json.Marshal(data)
+	assert.NoError(t, err)
+	assertJSONEqual(t, expectedJSON, string(bytes))
+}
+
+func TestClientSDKDataWithFlags(t *testing.T) {
+	flag1 := FlagValueData{
+		Key:                  "flagkey1",
+		Version:              1,
+		FlagVersion:          1000,
+		Value:                ldvalue.String("a"),
+		VariationIndex:       2,
+		Reason:               ldreason.NewEvalReasonFallthrough(),
+		TrackEvents:          true,
+		DebugEventsUntilDate: ldtime.UnixMillisecondTime(3000),
+	}
+	flag2 := FlagValueData{
+		Key:            "flagkey2",
+		Version:        2,
+		FlagVersion:    2000,
+		Value:          ldvalue.String("b"),
+		VariationIndex: -1,
+	}
+	data := NewClientSDKData().Flags(flag1, flag2)
+
+	expectedJSON := `{
+		"flagkey1": {
+			"version": 1,
+			"flagVersion": 1000,
+			"value": "a",
+			"variation": 2,
+			"reason": { "kind": "FALLTHROUGH" },
+			"trackEvents": true,
+			"debugEventsUntilDate": 3000
+		},
+		"flagkey2": {
+			"version": 2,
+			"flagVersion": 2000,
+			"value": "b"
+		}
+	}`
+	bytes, err := json.Marshal(data)
+	assert.NoError(t, err)
+	assertJSONEqual(t, expectedJSON, string(bytes))
+}

--- a/ldservices/client_sdk_data_test.go
+++ b/ldservices/client_sdk_data_test.go
@@ -4,10 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
-
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,9 +24,9 @@ func TestClientSDKDataWithFlags(t *testing.T) {
 		FlagVersion:          1000,
 		Value:                ldvalue.String("a"),
 		VariationIndex:       2,
-		Reason:               ldreason.NewEvalReasonFallthrough(),
+		Reason:               ldvalue.ObjectBuild().Set("kind", ldvalue.String("FALLTHROUGH")).Build(),
 		TrackEvents:          true,
-		DebugEventsUntilDate: ldtime.UnixMillisecondTime(3000),
+		DebugEventsUntilDate: uint64(3000),
 	}
 	flag2 := FlagValueData{
 		Key:            "flagkey2",

--- a/ldservices/server_sdk_data.go
+++ b/ldservices/server_sdk_data.go
@@ -20,6 +20,8 @@ func (f fakeFlagOrSegment) GetKey() string {
 
 // FlagOrSegment provides a stub implementation of KeyedData that has only "key" and "version" properties.
 // This may be enough for some testing purposes that don't require full flag or segment data.
+//
+// It also implements the eventsource.Event interface, simulating a "patch" event for the streaming service.
 func FlagOrSegment(key string, version int) KeyedData {
 	return fakeFlagOrSegment{Key: key, Version: version}
 }

--- a/ldservices/server_sdk_data_test.go
+++ b/ldservices/server_sdk_data_test.go
@@ -5,19 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func parseJSONAsMap(t *testing.T, s string) map[string]interface{} {
-	var fields map[string]interface{}
-	err := json.Unmarshal([]byte(s), &fields)
-	require.NoError(t, err)
-	return fields
-}
-
-func assertJSONEqual(t *testing.T, expected, actual string) {
-	assert.Equal(t, parseJSONAsMap(t, expected), parseJSONAsMap(t, actual))
-}
 
 func TestFlagOrSegment(t *testing.T) {
 	f := FlagOrSegment("my-key", 2)

--- a/ldservices/streaming_service.go
+++ b/ldservices/streaming_service.go
@@ -10,9 +10,19 @@ import (
 	"github.com/launchdarkly/go-test-helpers/httphelpers"
 )
 
-const serverSideSDKStreamingPath = "/all"
+const (
+	// The expected request path for server-side SDK stream requests.
+	ServerSideSDKStreamingPath     = "/all"
+	ClientSideSDKStreamingBasePath = "/eval"
+	MobileSDKStreamingBasePath     = "/meval"
+)
 
-// ServerSideStreamingServiceHandler creates an HTTP handler to mimic the LaunchDarkly server-side streaming service.
+// StreamingServiceHandler creates an HTTP handler that provides an SSE stream.
+//
+// This is a very simplistic implementation, not suitable for use in a real server that must handle multiple clients
+// simultaneously (it has a single channel for events, so if there are multiple requests the events will be divided
+// up random between them). Real applications should instead use the Server type in eventsource, which provides a
+// multiplexed publish-subscribe model.
 //
 // If initialEvent is non-nil, it will be sent at the beginning of each connection; you can pass a *ServerSDKData value
 // to generate a "put" event.
@@ -22,8 +32,28 @@ const serverSideSDKStreamingPath = "/all"
 // Calling Close() on the returned io.Closer causes the handler to close any active stream connections and refuse all
 // subsequent requests. You don't need to do this unless you need to force a stream to disconnect before the test
 // server has been shut down; shutting down the server will close connections anyway.
+func StreamingServiceHandler(
+	initialEvent eventsource.Event,
+	eventsCh <-chan eventsource.Event,
+) (http.Handler, io.Closer) {
+	closerCh := make(chan struct{})
+	sh := &streamingServiceHandler{
+		initialEvent: initialEvent,
+		eventsCh:     eventsCh,
+		closerCh:     closerCh,
+	}
+	c := &streamingServiceCloser{
+		closerCh: closerCh,
+	}
+	return sh, c
+}
+
+// ServerSideStreamingServiceHandler creates an HTTP handler to mimic the LaunchDarkly server-side streaming service.
 //
-//     initialData := ldservices.NewSDKData().Flags(flag1, flag2) // all connections will receive this in a "put" event
+// This is the same as StreamingServiceHandler, but enforces that the request path is ServerSideSDKStreamingPath and
+// that the method is GET.
+//
+//     initialData := ldservices.NewServerSDKData().Flags(flag1, flag2) // all connections will receive this in a "put" event
 //     eventsCh := make(chan eventsource.Event)
 //     handler, closer := ldservices.ServerSideStreamingHandler(initialData, eventsCh)
 //     server := httptest.NewServer(handler)
@@ -33,40 +63,67 @@ func ServerSideStreamingServiceHandler(
 	initialEvent eventsource.Event,
 	eventsCh <-chan eventsource.Event,
 ) (http.Handler, io.Closer) {
-	closerCh := make(chan struct{})
-	sh := &serverSideStreamingServiceHandler{
-		initialEvent: initialEvent,
-		eventsCh:     eventsCh,
-		closerCh:     closerCh,
-	}
-	h := httphelpers.HandlerForPath(serverSideSDKStreamingPath, httphelpers.HandlerForMethod("GET", sh, nil), nil)
-	c := &serverSideStreamingServiceCloser{
-		closerCh: closerCh,
-	}
-	return h, c
+	handler, closer := StreamingServiceHandler(initialEvent, eventsCh)
+	return httphelpers.HandlerForPath(ServerSideSDKStreamingPath, httphelpers.HandlerForMethod("GET", handler, nil), nil),
+		closer
 }
 
-type serverSideStreamingServiceHandler struct {
+// ClientSideStreamingServiceHandler creates an HTTP handler to mimic the LaunchDarkly client-side streaming service.
+//
+// This is the same as StreamingServiceHandler, but enforces that the request path and method correspond to one of
+// the client-side/mobile endpoints.
+//
+//     initialData := ldservices.NewClientSDKData().Flags(flag1, flag2) // all connections will receive this in a "put" event
+//     eventsCh := make(chan eventsource.Event)
+//     handler, closer := ldservices.ClientSideStreamingHandler(initialData, eventsCh)
+//     server := httptest.NewServer(handler)
+//     eventsCh <- myUpdatedFlag // push a "patch" event
+//     closer.Close() // force any current stream connections to be closed
+func ClientSideStreamingServiceHandler(
+	initialEvent eventsource.Event,
+	eventsCh <-chan eventsource.Event,
+) (http.Handler, io.Closer) {
+	handler, closer := StreamingServiceHandler(initialEvent, eventsCh)
+	return httphelpers.HandlerForPath(
+		ClientSideSDKStreamingBasePath,
+		httphelpers.HandlerForMethod("REPORT", handler, nil),
+		httphelpers.HandlerForPathRegex(
+			"^"+ClientSideSDKStreamingBasePath+"/user/.*",
+			httphelpers.HandlerForMethod("GET", handler, nil),
+			httphelpers.HandlerForPath(
+				MobileSDKStreamingBasePath,
+				httphelpers.HandlerForMethod("REPORT", handler, nil),
+				httphelpers.HandlerForPathRegex(
+					"^"+MobileSDKStreamingBasePath+"/user/.*",
+					httphelpers.HandlerForMethod("GET", handler, nil),
+					nil,
+				),
+			),
+		),
+	), closer
+}
+
+type streamingServiceHandler struct {
 	initialEvent eventsource.Event
 	eventsCh     <-chan eventsource.Event
 	closed       bool
 	closerCh     <-chan struct{}
 }
 
-type serverSideStreamingServiceCloser struct {
+type streamingServiceCloser struct {
 	closerCh  chan<- struct{}
 	closeOnce sync.Once
 }
 
-func (s *serverSideStreamingServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *streamingServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		log.Println("ServerSideStreamingServiceHandler can't be used with a ResponseWriter that does not support Flush")
+		log.Println("StreamingServiceHandler can't be used with a ResponseWriter that does not support Flush")
 		w.WriteHeader(500)
 		return
 	}
 	if s.closed {
-		log.Println("ServerSideStreamingServiceHandler received a request after it was closed")
+		log.Println("StreamingServiceHandler received a request after it was closed")
 		w.WriteHeader(500)
 		return
 	}
@@ -108,7 +165,7 @@ StreamLoop:
 	}
 }
 
-func (c *serverSideStreamingServiceCloser) Close() error {
+func (c *streamingServiceCloser) Close() error {
 	c.closeOnce.Do(func() {
 		close(c.closerCh)
 	})

--- a/ldservices/streaming_service_test.go
+++ b/ldservices/streaming_service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/launchdarkly/go-test-helpers/httphelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue"
 )
 
 func TestStreamingEndpoint(t *testing.T) {
@@ -39,17 +39,6 @@ func TestStreamingEndpoint(t *testing.T) {
 		assert.Equal(t, event2.Id(), event3.Id())
 		assert.Equal(t, event2.Event(), event3.Event())
 		assert.Equal(t, event2.Data(), event3.Data())
-	})
-}
-
-func TestStreamingEndpointReturns405ForWrongMethod(t *testing.T) {
-	eventsCh := make(chan eventsource.Event)
-	defer close(eventsCh)
-	handler, _ := StreamingServiceHandler(nil, eventsCh)
-
-	httphelpers.WithServer(handler, func(server *httptest.Server) {
-		resp, _ := http.DefaultClient.Post(server.URL+"/any-url-path", "text/plain", bytes.NewBufferString("hello"))
-		assert.Equal(t, 405, resp.StatusCode)
 	})
 }
 
@@ -128,6 +117,17 @@ func TestServerSideStreamingEndpointReturns404ForWrongURL(t *testing.T) {
 	httphelpers.WithServer(handler, func(server *httptest.Server) {
 		resp, _ := http.DefaultClient.Get(server.URL + "/some/other/path")
 		assert.Equal(t, 404, resp.StatusCode)
+	})
+}
+
+func TestServerSideStreamingEndpointReturns405ForWrongMethod(t *testing.T) {
+	eventsCh := make(chan eventsource.Event)
+	defer close(eventsCh)
+	handler, _ := ServerSideStreamingServiceHandler(nil, eventsCh)
+
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		resp, _ := http.DefaultClient.Post(server.URL+ServerSideSDKStreamingPath, "text/plain", bytes.NewBufferString("hello"))
+		assert.Equal(t, 405, resp.StatusCode)
 	})
 }
 

--- a/ldservices/streaming_service_test.go
+++ b/ldservices/streaming_service_test.go
@@ -11,25 +11,26 @@ import (
 	"github.com/launchdarkly/go-test-helpers/httphelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
-func TestServerSideStreamingEndpoint(t *testing.T) {
-	data := NewServerSDKData().Flags(FlagOrSegment("flagkey", 1))
+func TestStreamingEndpoint(t *testing.T) {
+	initialEvent := NewSSEEvent("", "put", "initial-data")
 	eventsCh := make(chan eventsource.Event)
 	defer close(eventsCh)
-	handler, closer := ServerSideStreamingServiceHandler(data, eventsCh)
+	handler, closer := StreamingServiceHandler(initialEvent, eventsCh)
 	defer closer.Close()
 
 	// Note that we have to use an httptest.Server instead of a hacked http.Client because eventsource does not
 	// work correctly with httptest.ResponseRecorder.
 	httphelpers.WithServer(handler, func(server *httptest.Server) {
-		stream, err := eventsource.SubscribeWithURL(server.URL + serverSideSDKStreamingPath)
+		stream, err := eventsource.SubscribeWithURL(server.URL + "/any-url-path")
 		require.NoError(t, err)
 		defer stream.Close()
 
 		event1 := <-stream.Events
 		assert.Equal(t, "put", event1.Event())
-		assert.Equal(t, data.Data(), event1.Data())
+		assert.Equal(t, initialEvent.Data(), event1.Data())
 
 		event2 := NewSSEEvent("my-id", "my-event", "my-data")
 		eventsCh <- event2
@@ -41,23 +42,34 @@ func TestServerSideStreamingEndpoint(t *testing.T) {
 	})
 }
 
-func TestServerSideStreamingEndpointClosesStreamWhenHandlerIsClosed(t *testing.T) {
-	data1 := NewServerSDKData().Flags(FlagOrSegment("flagkey1", 1))
-	data2 := NewServerSDKData().Flags(FlagOrSegment("flagkey2", 2))
+func TestStreamingEndpointReturns405ForWrongMethod(t *testing.T) {
+	eventsCh := make(chan eventsource.Event)
+	defer close(eventsCh)
+	handler, _ := StreamingServiceHandler(nil, eventsCh)
+
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		resp, _ := http.DefaultClient.Post(server.URL+"/any-url-path", "text/plain", bytes.NewBufferString("hello"))
+		assert.Equal(t, 405, resp.StatusCode)
+	})
+}
+
+func TestStreamingEndpointClosesStreamWhenHandlerIsClosed(t *testing.T) {
+	data1 := NewSSEEvent("", "put", "data1")
+	data2 := NewSSEEvent("", "put", "data2")
 
 	// Set up a stream handler that sends data1
-	handler1, closer1 := ServerSideStreamingServiceHandler(data1, nil)
+	handler1, closer1 := StreamingServiceHandler(data1, nil)
 	defer closer1.Close()
 
 	// Set up a stream handler that sends data2
-	handler2, closer2 := ServerSideStreamingServiceHandler(data2, nil)
+	handler2, closer2 := StreamingServiceHandler(data2, nil)
 	defer closer2.Close()
 
 	// Make it so the first request will get handler1, and the second request will get handler2
 	sequentialHandler := httphelpers.SequentialHandler(handler1, handler2)
 
 	httphelpers.WithServer(sequentialHandler, func(server *httptest.Server) {
-		stream, err := eventsource.SubscribeWithURL(server.URL+serverSideSDKStreamingPath,
+		stream, err := eventsource.SubscribeWithURL(server.URL,
 			eventsource.StreamOptionInitialRetry(time.Millisecond))
 		require.NoError(t, err)
 		defer stream.Close()
@@ -83,6 +95,32 @@ func TestServerSideStreamingEndpointClosesStreamWhenHandlerIsClosed(t *testing.T
 	})
 }
 
+func TestServerSideStreamingEndpoint(t *testing.T) {
+	data := NewServerSDKData().Flags(FlagOrSegment("flagkey", 1))
+	eventsCh := make(chan eventsource.Event)
+	defer close(eventsCh)
+	handler, closer := ServerSideStreamingServiceHandler(data, eventsCh)
+	defer closer.Close()
+
+	httphelpers.WithServer(handler, func(server *httptest.Server) {
+		stream, err := eventsource.SubscribeWithURL(server.URL + ServerSideSDKStreamingPath)
+		require.NoError(t, err)
+		defer stream.Close()
+
+		event1 := <-stream.Events
+		assert.Equal(t, "put", event1.Event())
+		assert.Equal(t, data.Data(), event1.Data())
+
+		event2 := NewSSEEvent("my-id", "my-event", "my-data")
+		eventsCh <- event2
+
+		event3 := <-stream.Events
+		assert.Equal(t, event2.Id(), event3.Id())
+		assert.Equal(t, event2.Event(), event3.Event())
+		assert.Equal(t, event2.Data(), event3.Data())
+	})
+}
+
 func TestServerSideStreamingEndpointReturns404ForWrongURL(t *testing.T) {
 	data := NewServerSDKData().Flags(FlagOrSegment("flagkey", 1))
 	handler, _ := ServerSideStreamingServiceHandler(data, nil)
@@ -93,14 +131,42 @@ func TestServerSideStreamingEndpointReturns404ForWrongURL(t *testing.T) {
 	})
 }
 
-func TestServerSideStreamingEndpointReturns405ForWrongMethod(t *testing.T) {
-	data := NewServerSDKData().Flags(FlagOrSegment("flagkey", 1))
+func TestClientSideStreamingEndpoint(t *testing.T) {
+	data := NewClientSDKData().Flags(FlagValueData{Key: "flagkey", Version: 1, Value: ldvalue.String("x")})
 	eventsCh := make(chan eventsource.Event)
 	defer close(eventsCh)
-	handler, _ := ServerSideStreamingServiceHandler(data, eventsCh)
+	handler, closer := ClientSideStreamingServiceHandler(data, eventsCh)
+	defer closer.Close()
 
 	httphelpers.WithServer(handler, func(server *httptest.Server) {
-		resp, _ := http.DefaultClient.Post(server.URL+serverSideSDKStreamingPath, "text/plain", bytes.NewBufferString("hello"))
-		assert.Equal(t, 405, resp.StatusCode)
+		stream1, err := eventsource.SubscribeWithURL(server.URL + ClientSideSDKStreamingBasePath + "/user/00000")
+		require.NoError(t, err)
+		defer stream1.Close()
+
+		event1 := <-stream1.Events
+		assert.Equal(t, "put", event1.Event())
+		assert.Equal(t, data.Data(), event1.Data())
+
+		event2 := FlagValueData{Key: "flagkey", Version: 2, Value: ldvalue.String("y")}
+		eventsCh <- event2
+
+		event3 := <-stream1.Events
+		assert.Equal(t, event2.Id(), event3.Id())
+		assert.Equal(t, event2.Event(), event3.Event())
+		assert.Equal(t, event2.Data(), event3.Data())
+
+		stream2, err := eventsource.SubscribeWithURL(server.URL + MobileSDKStreamingBasePath + "/user/00000")
+		require.NoError(t, err)
+		stream2.Close()
+
+		req3, _ := http.NewRequest("REPORT", server.URL+ClientSideSDKStreamingBasePath, bytes.NewReader([]byte("{}")))
+		stream3, err := eventsource.SubscribeWithRequestAndOptions(req3)
+		require.NoError(t, err)
+		stream3.Close()
+
+		req4, _ := http.NewRequest("REPORT", server.URL+MobileSDKStreamingBasePath, bytes.NewReader([]byte("{}")))
+		stream4, err := eventsource.SubscribeWithRequestAndOptions(req4)
+		require.NoError(t, err)
+		stream4.Close()
 	})
 }

--- a/ldservices/test_utils_test.go
+++ b/ldservices/test_utils_test.go
@@ -1,0 +1,20 @@
+package ldservices
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseJSONAsMap(t *testing.T, s string) map[string]interface{} {
+	var fields map[string]interface{}
+	err := json.Unmarshal([]byte(s), &fields)
+	require.NoError(t, err)
+	return fields
+}
+
+func assertJSONEqual(t *testing.T, expected, actual string) {
+	assert.Equal(t, parseJSONAsMap(t, expected), parseJSONAsMap(t, actual))
+}

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/LICENSE.txt
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2020 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/optional_string.go
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/optional_string.go
@@ -1,0 +1,145 @@
+package ldvalue
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// OptionalString represents a string that may or may not have a value. This is similar to using a
+// string pointer to distinguish between an empty string and nil, but it is safer because it does
+// not expose a pointer to any mutable value.
+//
+// Unlike Value, which can contain a value of any JSON-compatible type, OptionalString either
+// contains a string or nothing. To create an instance with a string value, use NewOptionalString.
+// There is no corresponding method for creating an instance with no value; simply use the empty
+// literal OptionalString{}.
+//
+//     os1 := NewOptionalString("this has a value")
+//     os2 := NewOptionalString("") // this has a value which is an empty string
+//     os2 := OptionalString{} // this does not have a value
+//
+// This can also be used as a convenient way to construct a string pointer within an expression.
+// For instance, this example causes myStringPointer to point to the string "x":
+//
+//     var myStringPointer *string = NewOptionalString("x").AsPointer()
+type OptionalString struct {
+	value    string
+	hasValue bool
+}
+
+// NewOptionalString constructs an OptionalString that has a string value.
+//
+// There is no corresponding method for creating an OptionalString with no value; simply use
+// the empty literal OptionalString{}.
+func NewOptionalString(value string) OptionalString {
+	return OptionalString{value: value, hasValue: true}
+}
+
+// NewOptionalStringFromPointer constructs an OptionalString from a string pointer. If the pointer
+// is non-nil, then the OptionalString copies its value; otherwise the OptionalString is empty.
+func NewOptionalStringFromPointer(valuePointer *string) OptionalString {
+	if valuePointer == nil {
+		return OptionalString{hasValue: false}
+	}
+	return OptionalString{value: *valuePointer, hasValue: true}
+}
+
+// IsDefined returns true if the OptionalString contains a string value, or false if it is empty.
+func (o OptionalString) IsDefined() bool {
+	return o.hasValue
+}
+
+// StringValue returns the OptionalString's value, or an empty string if it has no value.
+func (o OptionalString) StringValue() string {
+	return o.value
+}
+
+// OrElse returns the OptionalString's value if it has one, or else the specified fallback value.
+func (o OptionalString) OrElse(valueIfEmpty string) string {
+	if o.hasValue {
+		return o.value
+	}
+	return valueIfEmpty
+}
+
+// AsPointer returns the OptionalString's value as a string pointer if it has a value, or
+// nil otherwise.
+//
+// The string value, if any, is copied rather than returning to a pointer to the internal field.
+func (o OptionalString) AsPointer() *string {
+	if o.hasValue {
+		s := o.value
+		return &s
+	}
+	return nil
+}
+
+// AsValue converts the OptionalString to a Value, which is either Null() or a string value.
+func (o OptionalString) AsValue() Value {
+	if o.hasValue {
+		return String(o.value)
+	}
+	return Null()
+}
+
+// String is a debugging convenience method that returns a description of the OptionalString.
+// This is either the same as its string value, "[empty]" if it has a string value that is empty,
+// or "[none]" if it has no value.
+//
+// Since String() is used by methods like fmt.Printf, if you want to use the actual string value
+// of the OptionalString instead of this special representation, you should call StringValue():
+//
+//     s := OptionalString{}
+//     fmt.Printf("it is '%s'", s) // prints "it is '[none]'"
+//     fmt.Printf("it is '%s'", s.StringValue()) // prints "it is ''"
+func (o OptionalString) String() string {
+	if o.hasValue {
+		if o.value == "" {
+			return "[empty]"
+		}
+		return o.value
+	}
+	return "[none]"
+}
+
+// MarshalJSON converts the OptionalString to its JSON representation.
+//
+// The output will be either a JSON string or null. Note that the "omitempty" tag for a struct
+// field will not cause an empty OptionalString field to be omitted; it will be output as null.
+// If you want to completely omit a JSON property when there is no value, it must be a string
+// pointer instead of an OptionalString; use the AsPointer() method to get a pointer.
+func (o OptionalString) MarshalJSON() ([]byte, error) {
+	if o.hasValue {
+		return json.Marshal(o.value)
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON parses an OptionalString from JSON.
+//
+// The input must be either a JSON string or null.
+func (o *OptionalString) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 { // should not be possible, the parser doesn't pass empty slices to UnmarshalJSON
+		return errors.New("cannot parse empty data")
+	}
+	firstCh := data[0]
+	switch firstCh {
+	case 'n':
+		// Note that since Go 1.5, comparing a string to string([]byte) is optimized so it
+		// does not actually create a new string from the byte slice.
+		if string(data) == "null" {
+			*o = OptionalString{}
+			return nil
+		}
+	case '"':
+		var s string
+		e := json.Unmarshal(data, &s)
+		if e == nil {
+			*o = NewOptionalString(s)
+		}
+		return e
+	}
+	*o = OptionalString{}
+	return fmt.Errorf("unknown JSON token: %s", data)
+}

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/package_info.go
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/package_info.go
@@ -1,0 +1,15 @@
+// Package ldvalue provides an abstraction of the LaunchDarkly SDK's general value type. LaunchDarkly
+// supports the standard JSON data types of null, boolean, number, string, array, and object (map), for
+// any feature flag variation or custom user attribute. The ldvalue.Value type can contain any of these.
+//
+// For backward compatibility, some SDK methods and types still represent these values with the general
+// Go type "interface{}". Whenever there is an alternative that uses ldvalue.Value, that is preferred;
+// in the next major version release of the SDK, the uses of interface{} will be removed. There are two
+// reasons. First, interface{} can contain values that have no JSON encoding. Second, interface{} could
+// be an array, slice, or map, all of which are passed by reference and could be modified in one place
+// causing unexpected effects in another place. Value is guaranteed to be immutable and to contain only
+// JSON-compatible types as long as you do not use the UnsafeUseArbitraryValue() and
+// UnsafeArbitraryValue() methods (which will be removed in the future).
+//
+// This package also provides the helper type OptionalString, a safer alternative to using string pointers.
+package ldvalue

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_base.go
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_base.go
@@ -1,0 +1,424 @@
+package ldvalue
+
+import (
+	"encoding/json"
+)
+
+// Notes for future implementation changes:
+// In a future major version release, we will eliminate usage of interface{} as a flag value type and
+// user custom attribute type in the public API. At that point, we can also make the following changes:
+// - Replace interface{} with Value in all data model structs that are parsed from JSON (we may need to
+//   find a better parser implementation for this).
+// - Remove UnsafeUseArbitraryValue, UnsafeArbitraryValue, and the unsafeValueInstance field.
+
+// Value represents any of the data types supported by JSON, all of which can be used for a LaunchDarkly
+// feature flag variation or a custom user attribute.
+//
+// You cannot compare Value instances with the == operator, because the struct may contain a slice.
+// Value has an Equal method for this purpose; reflect.DeepEqual should not be used because it may not
+// always work correctly (see below).
+//
+// Values constructed with the regular constructors in this package are immutable. However, in the
+// current implementation, the SDK may also return a Value that is a wrapper for an interface{} value
+// that was parsed from JSON, which could be a mutable slice or map. For backward compatibility with
+// code that expects to be able to get the interface{} value without an extra deep-copy step, this
+// value is accessible directly with the UnsafeArbitraryValue method. Application code should not use
+// the Unsafe methods and does not need to be concerned with the difference between these two kinds of
+// Value, except that it is the reason why reflect.DeepEqual should not be used (that is, two Values
+// that are logically equal might not have exactly the same fields internally because one might be a
+// wrapper for an interface{}).
+type Value struct {
+	valueType ValueType
+	// Used when the value is a boolean.
+	boolValue bool
+	// Used when the value is a number.
+	numberValue float64
+	// Used when the value is a string.
+	stringValue string
+	// Used when the value is an array, if it was not created from an interface{}. We never expose
+	// this slice externally.
+	immutableArrayValue []Value
+	// Used when the value is an object, if it was not created from an interface{}. We never expose
+	// this slice externally.
+	immutableObjectValue map[string]Value
+	// Representation of the value as an interface{}. We *only* set this if the value was originally
+	// produced from an interface{} with UnsafeUseArbitraryValue.
+	unsafeValueInstance interface{}
+}
+
+// ValueType indicates which JSON type is contained in a Value.
+type ValueType int
+
+const (
+	// NullType describes a null value. Note that the zero value of ValueType is NullType, so the
+	// zero of Value is a null value.
+	NullType ValueType = iota
+	// BoolType describes a boolean value.
+	BoolType ValueType = iota
+	// NumberType describes a numeric value. JSON does not have separate types for int and float, but
+	// you can convert to either.
+	NumberType ValueType = iota
+	// StringType describes a string value.
+	StringType ValueType = iota
+	// ArrayType describes an array value.
+	ArrayType ValueType = iota
+	// ObjectType describes an object (a.k.a. map).
+	ObjectType ValueType = iota
+	// RawType describes a json.RawMessage value. This value will not be parsed or interpreted as
+	// any other data type, and can be accessed only by calling AsRaw().
+	RawType ValueType = iota
+)
+
+// String returns the name of the value type.
+func (t ValueType) String() string {
+	switch t {
+	case NullType:
+		return "null"
+	case BoolType:
+		return "bool"
+	case NumberType:
+		return "number"
+	case StringType:
+		return "string"
+	case ArrayType:
+		return "array"
+	case ObjectType:
+		return "object"
+	case RawType:
+		return "raw"
+	default:
+		return "unknown"
+	}
+}
+
+// Null creates a null Value.
+func Null() Value {
+	return Value{valueType: NullType}
+}
+
+// Bool creates a boolean Value.
+func Bool(value bool) Value {
+	return Value{valueType: BoolType, boolValue: value}
+}
+
+// Int creates a numeric Value from an integer.
+//
+// Note that all numbers are represented internally as the same type (float64), so Int(2) is
+// exactly equal to Float64(2).
+func Int(value int) Value {
+	return Float64(float64(value))
+}
+
+// Float64 creates a numeric Value from a float64.
+func Float64(value float64) Value {
+	return Value{valueType: NumberType, numberValue: value}
+}
+
+// String creates a string Value.
+func String(value string) Value {
+	return Value{valueType: StringType, stringValue: value}
+}
+
+// Raw creates an unparsed JSON Value.
+func Raw(value json.RawMessage) Value {
+	return Value{valueType: RawType, stringValue: string(value)}
+}
+
+// CopyArbitraryValue creates a Value from an arbitrary interface{} value of any type.
+//
+// If the value is nil, a boolean, an integer, a floating-point number, or a string, it becomes the
+// corresponding JSON primitive value type. If it is a slice of values ([]interface{} or
+// []Value), it is deep-copied to an array value. If it is a map of strings to values
+// (map[string]interface{} or map[string]Value), it is deep-copied to an object value.
+//
+// For all other types, the value is marshaled to JSON and then converted to the corresponding
+// Value type (unless marshalling returns an error, in which case it becomes Null()). This is
+// somewhat inefficient since it involves parsing the marshaled JSON.
+func CopyArbitraryValue(valueAsInterface interface{}) Value {
+	if valueAsInterface == nil {
+		return Null()
+	}
+	switch o := valueAsInterface.(type) {
+	case Value:
+		return o
+	case bool:
+		return Bool(o)
+	case int8:
+		return Float64(float64(o))
+	case uint8:
+		return Float64(float64(o))
+	case int16:
+		return Float64(float64(o))
+	case uint16:
+		return Float64(float64(o))
+	case int:
+		return Float64(float64(o))
+	case uint:
+		return Float64(float64(o))
+	case int32:
+		return Float64(float64(o))
+	case uint32:
+		return Float64(float64(o))
+	case float32:
+		return Float64(float64(o))
+	case float64:
+		return Float64(o)
+	case string:
+		return String(o)
+	case []interface{}:
+		a := make([]Value, len(o))
+		for i, v := range o {
+			a[i] = CopyArbitraryValue(v)
+		}
+		return Value{valueType: ArrayType, immutableArrayValue: a}
+	case []Value:
+		return ArrayOf(o...)
+	case map[string]interface{}:
+		m := make(map[string]Value, len(o))
+		for k, v := range o {
+			m[k] = CopyArbitraryValue(v)
+		}
+		return Value{valueType: ObjectType, immutableObjectValue: m}
+	case map[string]Value:
+		return CopyObject(o)
+	case json.RawMessage:
+		return Raw(o)
+	default:
+		jsonBytes, err := json.Marshal(valueAsInterface)
+		if err == nil {
+			var ret Value
+			err = json.Unmarshal(jsonBytes, &ret)
+			if err == nil {
+				return ret
+			}
+		}
+		return Null()
+	}
+}
+
+// Type returns the ValueType of the Value.
+func (v Value) Type() ValueType {
+	return v.valueType
+}
+
+// IsNull returns true if the Value is a null.
+func (v Value) IsNull() bool {
+	return v.valueType == NullType
+}
+
+// IsNumber returns true if the Value is numeric.
+func (v Value) IsNumber() bool {
+	return v.valueType == NumberType
+}
+
+// IsInt returns true if the Value is an integer.
+//
+// JSON does not have separate types for integer and floating-point values; they are both just numbers.
+// IsInt returns true if and only if the actual numeric value has no fractional component, so
+// Int(2).IsInt() and Float64(2.0).IsInt() are both true.
+func (v Value) IsInt() bool {
+	if v.valueType == NumberType {
+		return v.numberValue == float64(int(v.numberValue))
+	}
+	return false
+}
+
+// BoolValue returns the Value as a boolean.
+//
+// If the Value is not a boolean, it returns false.
+func (v Value) BoolValue() bool {
+	return v.valueType == BoolType && v.boolValue
+}
+
+// IntValue returns the value as an int.
+//
+// If the Value is not numeric, it returns zero. If the value is a number but not an integer, it is
+// rounded toward zero (truncated).
+func (v Value) IntValue() int {
+	if v.valueType == NumberType {
+		return int(v.numberValue)
+	}
+	return 0
+}
+
+// Float64Value returns the value as a float64.
+//
+// If the Value is not numeric, it returns zero.
+func (v Value) Float64Value() float64 {
+	if v.valueType == NumberType {
+		return v.numberValue
+	}
+	return 0
+}
+
+// StringValue returns the value as a string.
+//
+// If the value is not a string, it returns an empty string.
+//
+// This is different from String(), which returns a concise string representation of any value type.
+func (v Value) StringValue() string {
+	if v.valueType == StringType {
+		return v.stringValue
+	}
+	return ""
+}
+
+// AsOptionalString converts the value to the OptionalString type, which contains either a string
+// value or nothing if the original value was not a string.
+func (v Value) AsOptionalString() OptionalString {
+	if v.valueType == StringType {
+		return NewOptionalString(v.stringValue)
+	}
+	return OptionalString{}
+}
+
+// AsRaw returns the value as a json.RawMessage.
+//
+// If the value was originally created from a RawMessage, it returns the same value. For all other
+// values, it converts the value to its JSON representation and returns that representation.
+func (v Value) AsRaw() json.RawMessage {
+	if v.valueType == RawType {
+		return json.RawMessage(v.stringValue)
+	}
+	bytes, err := json.Marshal(v)
+	if err == nil {
+		return json.RawMessage(bytes)
+	}
+	return nil
+}
+
+// AsArbitraryValue returns the value in its simplest Go representation, typed as interface{}.
+//
+// This is nil for a null value; for primitive types, it is bool, float64, or string (all numbers
+// are represented as float64 because that is Go's default when parsing from JSON).
+//
+// Arrays and objects are represented as []interface{} and map[string]interface{}. They are
+// deep-copied, which preserves immutability of the Value but may be an expensive operation.
+// To examine array and object values without copying the whole data structure, use getter
+// methods: Count, Keys, GetByIndex, TryGetByIndex, GetByKey, TryGetByKey.
+func (v Value) AsArbitraryValue() interface{} {
+	switch v.valueType {
+	case NullType:
+		return nil
+	case BoolType:
+		return v.boolValue
+	case NumberType:
+		return v.numberValue
+	case StringType:
+		return v.stringValue
+	case ArrayType:
+		if v.immutableArrayValue != nil {
+			ret := make([]interface{}, len(v.immutableArrayValue))
+			for i, element := range v.immutableArrayValue {
+				ret[i] = element.AsArbitraryValue()
+			}
+			return ret
+		}
+		return deepCopyArbitraryValue(v.unsafeValueInstance)
+	case ObjectType:
+		if v.immutableObjectValue != nil {
+			ret := make(map[string]interface{}, len(v.immutableObjectValue))
+			for key, element := range v.immutableObjectValue {
+				ret[key] = element.AsArbitraryValue()
+			}
+			return ret
+		}
+		return deepCopyArbitraryValue(v.unsafeValueInstance)
+	case RawType:
+		return v.AsRaw()
+	}
+	return nil // should not be possible
+}
+
+func deepCopyArbitraryValue(value interface{}) interface{} {
+	switch o := value.(type) {
+	case []interface{}:
+		ret := make([]interface{}, len(o))
+		for i, element := range o {
+			ret[i] = deepCopyArbitraryValue(element)
+		}
+		return ret
+	case map[string]interface{}:
+		ret := make(map[string]interface{}, len(o))
+		for key, element := range o {
+			ret[key] = deepCopyArbitraryValue(element)
+		}
+		return ret
+	}
+	return value
+}
+
+// String converts the value to a string representation, equivalent to JSONString().
+//
+// This is different from StringValue, which returns the actual string for a string value or an empty
+// string for anything else. For instance, Int(2).StringValue() returns "2" and String("x").StringValue()
+// returns "\"x\"", whereas Int(2).AsString() returns "" and String("x").AsString() returns
+// "x".
+//
+// This method is provided because it is common to use the Stringer interface as a quick way to
+// summarize the contents of a value. The simplest way to do so in this case is to use the JSON
+// representation.
+func (v Value) String() string {
+	return v.JSONString()
+}
+
+// Equal tests whether this Value is equal to another, in both type and value.
+//
+// For arrays and objects, this is a deep equality test. Do not use reflect.DeepEqual with
+// Value; it currently is not guaranteed to work due to possible differences in how the same
+// value may be represented internally.
+func (v Value) Equal(other Value) bool {
+	if v.valueType == other.valueType {
+		switch v.valueType {
+		case NullType:
+			return true
+		case BoolType:
+			return v.boolValue == other.boolValue
+		case NumberType:
+			return v.numberValue == other.numberValue
+		case StringType, RawType:
+			return v.stringValue == other.stringValue
+		case ArrayType:
+			n := v.Count()
+			if n == other.Count() {
+				for i := 0; i < n; i++ {
+					if !v.GetByIndex(i).Equal(other.GetByIndex(i)) {
+						return false
+					}
+				}
+				return true
+			}
+			return false
+		case ObjectType:
+			keys := v.Keys()
+			if len(keys) == other.Count() {
+				for _, key := range keys {
+					v0 := v.GetByKey(key)
+					if v1, found := other.TryGetByKey(key); !found || !v0.Equal(v1) {
+						return false
+					}
+				}
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+// AsPointer returns either a pointer to a copy of this Value, or nil if it is a null value.
+//
+// This may be desirable if you are serializing a struct that contains a Value, and you want
+// that field to be completely omitted if the Value is null; since the "omitempty" tag only
+// works for pointers, you can declare the field as a *Value like so:
+//
+//     type MyJsonStruct struct {
+//         AnOptionalField *Value `json:"anOptionalField,omitempty"`
+//     }
+//     s := MyJsonStruct{AnOptionalField: someValue.AsPointer()}
+func (v Value) AsPointer() *Value {
+	if v.IsNull() {
+		return nil
+	}
+	return &v
+}

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_complex_types.go
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_complex_types.go
@@ -1,0 +1,227 @@
+package ldvalue
+
+// This file contains types and methods that are only used for complex data structures (array and
+// object), in the fully immutable model where no slices, maps, or interface{} values are exposed.
+
+// ArrayBuilder is a builder created by ArrayBuild(), for creating immutable arrays.
+type ArrayBuilder interface {
+	// Add appends an element to the array builder.
+	Add(value Value) ArrayBuilder
+	// Build creates a Value containing the previously added array elements. Continuing to modify the
+	// same builder by calling Add after that point does not affect the returned array.
+	Build() Value
+}
+
+type arrayBuilderImpl struct {
+	copyOnWrite bool
+	output      []Value
+}
+
+// ObjectBuilder is a builder created by ObjectBuild(), for creating immutable JSON objects.
+type ObjectBuilder interface {
+	// Set sets a key-value pair in the object builder.
+	Set(key string, value Value) ObjectBuilder
+	// Build creates a Value containing the previously specified key-value pairs. Continuing to modify
+	// the same builder by calling Set after that point does not affect the returned object.
+	Build() Value
+}
+
+type objectBuilderImpl struct {
+	copyOnWrite bool
+	output      map[string]Value
+}
+
+// ArrayOf creates an array Value from a list of Values.
+//
+// This requires a slice copy to ensure immutability; otherwise, an existing slice could be passed
+// using the spread operator, and then modified. However, since Value is itself immutable, it does
+// not need to deep-copy each item.
+func ArrayOf(items ...Value) Value {
+	copiedItems := make([]Value, len(items))
+	copy(copiedItems, items)
+	return Value{valueType: ArrayType, immutableArrayValue: copiedItems}
+}
+
+// ArrayBuild creates a builder for constructing an immutable array Value.
+//
+//     arrayValue := ldvalue.ArrayBuild().Add(ldvalue.Int(100)).Add(ldvalue.Int(200)).Build()
+func ArrayBuild() ArrayBuilder {
+	return ArrayBuildWithCapacity(1)
+}
+
+// ArrayBuildWithCapacity creates a builder for constructing an immutable array Value.
+//
+// The capacity parameter is the same as the capacity of a slice, allowing you to preallocate space
+// if you know the number of elements; otherwise you can pass zero.
+//
+//     arrayValue := ldvalue.ArrayBuildWithCapacity(2).Add(ldvalue.Int(100)).Add(ldvalue.Int(200)).Build()
+func ArrayBuildWithCapacity(capacity int) ArrayBuilder {
+	return &arrayBuilderImpl{output: make([]Value, 0, capacity)}
+}
+
+func (b *arrayBuilderImpl) Add(value Value) ArrayBuilder {
+	if b.copyOnWrite {
+		n := len(b.output)
+		newSlice := make([]Value, n, n+1)
+		copy(newSlice[0:n], b.output)
+		b.output = newSlice
+		b.copyOnWrite = false
+	}
+	b.output = append(b.output, value)
+	return b
+}
+
+func (b *arrayBuilderImpl) Build() Value {
+	b.copyOnWrite = true
+	return Value{valueType: ArrayType, immutableArrayValue: b.output}
+}
+
+// CopyObject creates a Value by copying an existing map[string]Value.
+//
+// If you want to copy a map[string]interface{} instead, use CopyArbitraryValue.
+func CopyObject(m map[string]Value) Value {
+	return Value{valueType: ObjectType, immutableObjectValue: copyValueMap(m)}
+}
+
+// ObjectBuild creates a builder for constructing an immutable JSON object Value.
+//
+//     objValue := ldvalue.ObjectBuild().Set("a", ldvalue.Int(100)).Set("b", ldvalue.Int(200)).Build()
+func ObjectBuild() ObjectBuilder {
+	return ObjectBuildWithCapacity(1)
+}
+
+// ObjectBuildWithCapacity creates a builder for constructing an immutable JSON object Value.
+//
+// The capacity parameter is the same as the capacity of a map, allowing you to preallocate space
+// if you know the number of elements; otherwise you can pass zero.
+//
+//     objValue := ldvalue.ObjectBuildWithCapacity(2).Set("a", ldvalue.Int(100)).Set("b", ldvalue.Int(200)).Build()
+func ObjectBuildWithCapacity(capacity int) ObjectBuilder {
+	return &objectBuilderImpl{output: make(map[string]Value, capacity)}
+}
+
+func (b *objectBuilderImpl) Set(name string, value Value) ObjectBuilder {
+	if b.copyOnWrite {
+		b.output = copyValueMap(b.output)
+		b.copyOnWrite = false
+	}
+	b.output[name] = value
+	return b
+}
+
+func (b *objectBuilderImpl) Build() Value {
+	b.copyOnWrite = true
+	return Value{valueType: ObjectType, immutableObjectValue: b.output}
+}
+
+// Count returns the number of elements in an array or JSON object.
+//
+// For values of any other type, it returns zero.
+func (v Value) Count() int {
+	switch v.valueType {
+	case ArrayType:
+		if v.immutableArrayValue != nil {
+			return len(v.immutableArrayValue)
+		}
+		if a, ok := v.unsafeValueInstance.([]interface{}); ok {
+			return len(a)
+		}
+	case ObjectType:
+		if v.immutableObjectValue != nil {
+			return len(v.immutableObjectValue)
+		}
+		if m, ok := v.unsafeValueInstance.(map[string]interface{}); ok {
+			return len(m)
+		}
+	}
+	return 0
+}
+
+// GetByIndex gets an element of an array by index.
+//
+// If the value is not an array, or if the index is out of range, it returns Null().
+func (v Value) GetByIndex(index int) Value {
+	ret, _ := v.TryGetByIndex(index)
+	return ret
+}
+
+// TryGetByIndex gets an element of an array by index, with a second return value of true if
+// successful.
+//
+// If the value is not an array, or if the index is out of range, it returns (Null(), false).
+func (v Value) TryGetByIndex(index int) (Value, bool) {
+	if v.valueType == ArrayType {
+		if v.immutableArrayValue != nil {
+			if index >= 0 && index < len(v.immutableArrayValue) {
+				return v.immutableArrayValue[index], true
+			}
+		} else if a, ok := v.unsafeValueInstance.([]interface{}); ok {
+			if index >= 0 && index < len(a) {
+				return CopyArbitraryValue(a[index]), true
+			}
+		}
+	}
+	return Null(), false
+}
+
+// Keys returns the keys of a JSON object as a slice.
+//
+// The method copies the keys. If the value is not an object, it returns an empty slice.
+func (v Value) Keys() []string {
+	if v.valueType == ObjectType {
+		if v.immutableObjectValue != nil {
+			ret := make([]string, len(v.immutableObjectValue))
+			i := 0
+			for key := range v.immutableObjectValue {
+				ret[i] = key
+				i++
+			}
+			return ret
+		}
+		if m, ok := v.unsafeValueInstance.(map[string]interface{}); ok {
+			ret := make([]string, len(m))
+			i := 0
+			for key := range m {
+				ret[i] = key
+				i++
+			}
+			return ret
+		}
+	}
+	return nil
+}
+
+// GetByKey gets a value from a JSON object by key.
+//
+// If the value is not an object, or if the key is not found, it returns Null().
+func (v Value) GetByKey(name string) Value {
+	ret, _ := v.TryGetByKey(name)
+	return ret
+}
+
+// TryGetByKey gets a value from a JSON object by key, with a second return value of true if
+// successful.
+//
+// If the value is not an object, or if the key is not found, it returns (Null(), false).
+func (v Value) TryGetByKey(name string) (Value, bool) {
+	if v.valueType == ObjectType {
+		if v.immutableObjectValue != nil {
+			ret, ok := v.immutableObjectValue[name]
+			return ret, ok
+		}
+		if m, ok := v.unsafeValueInstance.(map[string]interface{}); ok {
+			if innerValue, ok := m[name]; ok {
+				return CopyArbitraryValue(innerValue), true
+			}
+		}
+	}
+	return Null(), false
+}
+
+func copyValueMap(m map[string]Value) map[string]Value {
+	ret := make(map[string]Value, len(m))
+	for k, v := range m {
+		ret[k] = v
+	}
+	return ret
+}

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_serialization.go
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_serialization.go
@@ -1,0 +1,137 @@
+package ldvalue
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// This file contains methods for converting Value to and from JSON.
+
+// JSONString returns the JSON representation of the value.
+func (v Value) JSONString() string {
+	// The following is somewhat redundant with json.Marshal, but it avoids the overhead of
+	// converting between byte arrays and strings.
+	switch v.valueType {
+	case NullType:
+		return "null"
+	case BoolType:
+		if v.boolValue {
+			return "true"
+		}
+		return "false"
+	case NumberType:
+		if v.IsInt() {
+			return strconv.Itoa(int(v.numberValue))
+		}
+		return strconv.FormatFloat(v.numberValue, 'f', -1, 64)
+	}
+	// For all other types, we rely on our custom marshaller.
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		// It shouldn't be possible for marshalling to fail, because Value should only contain
+		// JSON-compatible types. However, UnsafeUserArbitraryValue and UnsafeArbitraryValue do
+		// allow a badly behaved application to put an incompatible type into an array or map.
+		// In that case we simply discard the value.
+		return ""
+	}
+	return string(bytes)
+}
+
+// MarshalJSON converts the Value to its JSON representation.
+//
+// Note that the "omitempty" tag for a struct field will not cause an empty Value field to be
+// omitted; it will be output as null. If you want to completely omit a JSON property when there
+// is no value, it must be a pointer; use AsPointer().
+func (v Value) MarshalJSON() ([]byte, error) {
+	switch v.valueType {
+	case NullType:
+		return []byte("null"), nil
+	case BoolType:
+		if v.boolValue {
+			return []byte("true"), nil
+		}
+		return []byte("false"), nil
+	case NumberType:
+		if v.IsInt() {
+			return []byte(strconv.Itoa(int(v.numberValue))), nil
+		}
+		return []byte(strconv.FormatFloat(v.numberValue, 'f', -1, 64)), nil
+	case StringType:
+		return json.Marshal(v.stringValue)
+	case ArrayType:
+		if v.immutableArrayValue != nil {
+			return json.Marshal(v.immutableArrayValue)
+		}
+		return json.Marshal(v.unsafeValueInstance)
+	case ObjectType:
+		if v.immutableObjectValue != nil {
+			return json.Marshal(v.immutableObjectValue)
+		}
+		return json.Marshal(v.unsafeValueInstance)
+	case RawType:
+		if v.unsafeValueInstance != nil {
+			if o, ok := v.unsafeValueInstance.(json.RawMessage); ok {
+				return o, nil
+			}
+		}
+		return []byte(v.stringValue), nil
+	}
+	return nil, errors.New("unknown data type") // should not be possible
+}
+
+// UnmarshalJSON parses a Value from JSON.
+func (v *Value) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 { // should not be possible, the parser doesn't pass empty slices to UnmarshalJSON
+		return errors.New("cannot parse empty data")
+	}
+	firstCh := data[0]
+	switch firstCh {
+	case 'n':
+		// Note that since Go 1.5, comparing a string to string([]byte) is optimized so it
+		// does not actually create a new string from the byte slice.
+		if string(data) == "null" {
+			*v = Null()
+			return nil
+		}
+	case 't', 'f':
+		if string(data) == "true" {
+			*v = Bool(true)
+			return nil
+		}
+		if string(data) == "false" {
+			*v = Bool(false)
+			return nil
+		}
+	case '"':
+		var s string
+		e := json.Unmarshal(data, &s)
+		if e == nil {
+			*v = String(s)
+		}
+		return e
+	case '[':
+		var a []Value
+		e := json.Unmarshal(data, &a)
+		if e == nil {
+			*v = Value{valueType: ArrayType, immutableArrayValue: a}
+		}
+		return e
+	case '{':
+		var o map[string]Value
+		e := json.Unmarshal(data, &o)
+		if e == nil {
+			*v = Value{valueType: ObjectType, immutableObjectValue: o}
+		}
+		return e
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9': // note, JSON does not allow a leading '.'
+		var n float64
+		e := json.Unmarshal(data, &n)
+		if e == nil {
+			*v = Value{valueType: NumberType, numberValue: n}
+		}
+		return e
+	}
+	return fmt.Errorf("unknown JSON token: %s", data)
+}

--- a/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_unsafe_conversion.go
+++ b/vendor/gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue/value_unsafe_conversion.go
@@ -1,0 +1,57 @@
+package ldvalue
+
+import "encoding/json"
+
+// This file contains methods to convert between Value and the empty interface{} type without
+// deep-copying. These will be removed in a future release for Go SDK v5.
+
+// UnsafeUseArbitraryValue creates a Value that wraps an arbitrary Go value as-is. Application
+// code should never use this method, since it can break the immutability contract of Value.
+//
+// This method and Value.UnsafeArbitraryValue() are provided for backward compatibility in v4 of
+// the Go SDK, where flag values are stored internally as interface{} and can be accessed as
+// interface{} with JsonVariation() or JsonVariationDetail(); using the original value avoids
+// adding an unexpected deep-copy step for code that is using those methods. In a future version,
+// that behavior will be removed and the SDK will use only immutable Value instances.
+//
+// The allowable value types are the same as for CopyArbitraryValue.
+//
+// Deprecated: Application code should use CopyArbitraryValue instead of this (or just use the
+// regular value constructors such as Bool() and ObjectBuild()). This method will be removed in a
+// future version.
+func UnsafeUseArbitraryValue(valueAsInterface interface{}) Value {
+	if valueAsInterface == nil {
+		return Null()
+	}
+	switch o := valueAsInterface.(type) {
+	case []interface{}:
+		return Value{valueType: ArrayType, unsafeValueInstance: o}
+	case map[string]interface{}:
+		return Value{valueType: ObjectType, unsafeValueInstance: o}
+	case json.RawMessage:
+		return Value{valueType: RawType, unsafeValueInstance: o}
+	default:
+		// For primitive types, we don't bother wrapping the original interface{}, we just convert it
+		// to our own representation of the primitive type. That's because the overhead from copying
+		// the value back to an interface{}, if the application requested it that way, is negligible
+		// and applications are unlikely to be using JsonVariation for primitive types anyway. It
+		// matters more with arrays and objects, where (until we remove the deprecated JsonVariation)
+		// we don't want it to suddenly be incurring the overhead of a deep copy when they get the
+		// value.
+		return CopyArbitraryValue(valueAsInterface)
+	}
+}
+
+// UnsafeArbitraryValue converts the Value to its corresponding Go type as an interface{} -
+// or, if it was created from an existing slice or map using UnsafeUseArbitraryValue, it
+// returns that original value as an interface{} without deep-copying. See
+// UnsafeUseArbitraryValue for more information.
+//
+// Deprecated: Application code should use AsArbitraryValue instead. This method will be
+// removed in a future version.
+func (v Value) UnsafeArbitraryValue() interface{} {
+	if v.unsafeValueInstance != nil {
+		return v.unsafeValueInstance
+	}
+	return v.AsArbitraryValue()
+}


### PR DESCRIPTION
This extends the `ldservices` package so it can simulate not only the server-side streaming endpoint, but the client-side/mobile ones.

Right now, the only use case for this is to support test apps that simulate LD endpoints for testing various SDKs. I've implemented it here in `go-test-helpers`, instead of just in those test apps, because 1. it logically fits with the other stuff in the `ldservices` package and 2. if we ever create a client-side Go SDK in the future, we will use this in the same way that the server-side Go SDK currently uses the package.