### PR TITLE
update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - prealloc
     - staticcheck
     - structcheck
+    - stylecheck
     - typecheck
     - unconvert
     - unparam
@@ -43,7 +44,9 @@ linters:
 linters-settings:
   gofmt:
     simplify: false
-
+  goimports:
+    local-prefixes: gopkg.in/launchdarkly,github.com/launchdarkly
+  
 issues:
   exclude-use-default: false
   max-same-issues: 1000

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,16 +3,44 @@ run:
   tests: false
 
 linters:
-  enable-all: true
-  disable:
-    - funlen # allow long/complex functions for now
-    - gocognit # allow long/complex functions for now
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
     - goconst
-    - gomnd # extremely aggressive linter that complains about all numeric literals, even just adding 1 to something (https://github.com/tommy-muehle/go-mnd)
-    - wsl # enforces a very specific style with an idiosyncratic definition of what "cuddling" is
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - megacheck
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
   fast: false
 
-linter-settings:
+linters-settings:
   gofmt:
     simplify: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-GOLANGCI_LINT_VERSION=v1.23.7
+GOLANGCI_LINT_VERSION=v1.27.0
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/httphelpers/certificates.go
+++ b/httphelpers/certificates.go
@@ -78,7 +78,7 @@ func MakeServerWithCert(certFilePath, keyFilePath string, handler http.Handler) 
 	server.TLS = &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}
-	server.TLS.BuildNameToCertificate() //nolint:staticcheck // method is deprecated but we still need to support older Gos
+	server.TLS.BuildNameToCertificate()
 	server.StartTLS()
 	return server, nil
 }


### PR DESCRIPTION
Besides updating the linter version, removing an unnecessary directive, and fixing a typo ("linter-settings"), this changes the config to specify the desired linters instead of using the deprecated "enable-all" option.