### PR TITLE
add test sandboxing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Subpackage `httphelpers` provides convenience wrappers for using `net/http` and 
 
 Subpackage `ldservices` is specifically for testing LaunchDarkly SDK client components; it provides HTTP handlers that simulate the service endpoints used by the SDK.
 
+Subpackage `testbox` provides the ability to write tests-of-tests within the Go testing framework.
+
 ## Usage
 
 Import any of these packages in your test code:
@@ -23,10 +25,11 @@ import (
     "github.com/launchdarkly/go-test-helpers"
     "github.com/launchdarkly/go-test-helpers/httphelpers"
     "github.com/launchdarkly/go-test-helpers/ldservices"
+    "github.com/launchdarkly/go-test-helpers/testbox"
 )
 ```
 
-Breaking changes will only be made in a new major version. It is advisable to use a dependency manager to pin these dependencies to a major version branch (`v1`, etc.).
+Breaking changes will only be made in a new major version. It is advisable to use a dependency manager to pin these dependencies to a module version or a major version branch.
 
 ## Contributing
 

--- a/testbox/interface.go
+++ b/testbox/interface.go
@@ -1,0 +1,63 @@
+package testbox
+
+import "github.com/stretchr/testify/require"
+
+// TestingT is a subset of the testing.T interface that allows tests to run in either a real test
+// context, or a mock test scope that is decoupled from the regular testing framework (SandboxTest).
+//
+// This may be useful in a scenario where you have a contract test that verifies the behavior of some
+// unknown interface implementation. In order to verify that the contract test is reliable, you could
+// create implementations that either adhere to the contract or deliberately break it, run the contract
+// test against those, and verify that the test fails if and only if it should fail.
+//
+// The reason this cannot be done with the Go testing package alone is that the standard testing.T type
+// cannot be created from within test code; instances are always passed in from the test framework.
+// Therefore, the contract test would have to be run against the actual *testing.T instance that
+// belongs to the test-of-the-test, and if it failed in a situation when we actually wanted it to
+// to fail, that would be incorrectly reported as a failure of the test-of-the-test.
+//
+// To work around this limitation of the testing package, this package provides a TestingT interface
+// that has two implementations: real and mock. Test logic can then be written against this TestingT,
+// rather than *testing.T.
+//
+//     func RunContractTests(t *testing.T, impl InterfaceUnderTest) {
+//         runContractTests(testbox.RealTest(t))
+//     }
+//
+//     func runContractTests(abstractT testbox.TestingT, impl InterfaceUnderTest) {
+//         assert.True(abstractT, impl.SomeConditionThatShouldBeTrueForTheseInputs(someParams))
+//         abstractT.Run("subtest", func(abstractSubT helpers.TestingT) { ... }
+//     }
+//
+//     func TestContractTestFailureCondition(t *testing.T) {
+//         impl := createDeliberatelyBrokenImplementation()
+//         result := testbox.SandboxTest(func(abstractT testbox.TestingT) {
+//             runContractTests(abstractT, impl) })
+//         assert.True(t, result.Failed // we expect it to fail
+//         assert.Len(t, result.Failures, 1)
+//     }
+//
+// TestingT includes the same subsets of testing.T methods that are defined in the TestingT interfaces
+// of github.com/stretchr/testify/assert and github.com/stretchr/testify/require, so all assertions in
+// those packages will work. It also provides Run, Skip, and SkipNow. It does not support Parallel.
+type TestingT interface {
+	require.TestingT
+	// Run runs a subtest with a new TestingT that applies only to the scope of the subtest. It is
+	// equivalent to the same method in testing.T, except the subtest takes a parameter of type TestingT
+	// instead of *testing.T.
+	//
+	// If the subtest fails, the parent test also fails, but FailNow and SkipNow on the subtest do not
+	// cause the parent test to exit early.
+	Run(name string, action func(TestingT))
+
+	// Failed tells whether whether any assertions in the test have failed so far. It is equivalent to
+	// the same method in testing.T.
+	Failed() bool
+
+	// Skip marks the test as skipped and exits early, logging a message. It is equivalent to the same
+	// method in testing.T.
+	Skip(args ...interface{})
+
+	// SkipNow marks the test as skipped and exits early. It is equivalent to the same method in testing.T.
+	SkipNow()
+}

--- a/testbox/package_info.go
+++ b/testbox/package_info.go
@@ -1,0 +1,3 @@
+// Package testbox provides the ability to run test logic that uses a subset of Go's testing.T
+// methods either inside or outside the regular testing environment.
+package testbox

--- a/testbox/real.go
+++ b/testbox/real.go
@@ -1,0 +1,38 @@
+package testbox
+
+import "testing"
+
+type realTestingT struct {
+	t *testing.T
+}
+
+// RealTest provides an implementation of TestingT for running test logic in a regular test context.
+//
+// See TestingT for details.
+func RealTest(t *testing.T) TestingT {
+	return realTestingT{t}
+}
+
+func (r realTestingT) Errorf(format string, args ...interface{}) {
+	r.t.Errorf(format, args...) // COVERAGE: can't do this in test_sandbox_test; it'll cause a real failure
+}
+
+func (r realTestingT) Run(name string, action func(TestingT)) {
+	r.t.Run(name, func(tt *testing.T) { action(realTestingT{tt}) })
+}
+
+func (r realTestingT) FailNow() {
+	r.t.FailNow() // COVERAGE: can't do this in test_sandbox_test; it'll cause a real failure
+}
+
+func (r realTestingT) Failed() bool {
+	return r.t.Failed()
+}
+
+func (r realTestingT) Skip(args ...interface{}) {
+	r.t.Skip(args...)
+}
+
+func (r realTestingT) SkipNow() {
+	r.t.SkipNow()
+}

--- a/testbox/real_test.go
+++ b/testbox/real_test.go
@@ -1,0 +1,81 @@
+package testbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRealTest(t *testing.T) {
+	// can't test failure cases, since then *this* test would fail
+
+	t.Run("success", func(t *testing.T) {
+		rt := RealTest(t)
+		assert.True(rt, true)
+
+		assert.False(t, rt.Failed())
+		assert.False(t, t.Failed())
+		assert.False(t, t.Skipped())
+	})
+
+	t.Run("subtest success", func(t *testing.T) {
+		ran := false
+
+		rt := RealTest(t)
+		rt.Run("sub", func(u TestingT) {
+			ran = true
+			assert.True(u, true)
+		})
+
+		assert.True(t, ran)
+
+		assert.False(t, rt.Failed())
+		assert.False(t, t.Failed())
+		assert.False(t, t.Skipped())
+	})
+
+	t.Run("skip", func(t *testing.T) { // this test will always be reported as skipped
+		rt := RealTest(t)
+		rt.Skip()
+
+		assert.True(t, false) // won't execute because we exited early on Skip
+	})
+
+	t.Run("subtest skip", func(t *testing.T) {
+		ran := false
+		continued := false
+
+		rt := RealTest(t)
+		rt.Run("sub", func(u TestingT) {
+			ran = true
+			u.Skip("let's skip this")
+			continued = true
+		})
+
+		assert.True(t, ran)
+		assert.False(t, continued)
+
+		assert.False(t, rt.Failed())
+		assert.False(t, t.Failed())
+		assert.False(t, t.Skipped())
+	})
+
+	t.Run("subtest SkipNow", func(t *testing.T) {
+		ran := false
+		continued := false
+
+		rt := RealTest(t)
+		rt.Run("sub", func(u TestingT) {
+			ran = true
+			u.SkipNow()
+			continued = true
+		})
+
+		assert.True(t, ran)
+		assert.False(t, continued)
+
+		assert.False(t, rt.Failed())
+		assert.False(t, t.Failed())
+		assert.False(t, t.Skipped())
+	})
+}

--- a/testbox/sandbox.go
+++ b/testbox/sandbox.go
@@ -1,0 +1,150 @@
+package testbox
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// SandboxResult describes the aggregate test state produced by calling SandboxTest.
+type SandboxResult struct {
+	// True if any failures were reported during SandboxTest.
+	Failed bool
+
+	// True if the test run with SandboxTest called Skip or SkipNow. This is only true if
+	// the top-level TestingT was skipped, not any subtests.
+	Skipped bool
+
+	// All failures logged during SandboxTest, including subtests.
+	Failures []LogItem
+
+	// All tests that were skipped during SandboxTest, including subtests.
+	Skips []LogItem
+}
+
+type testState struct {
+	failed   bool
+	skipped  bool
+	failures []LogItem
+	skips    []LogItem
+}
+
+// TestPath identifies the level of test that failed or skipped. SandboxResult.Failures and
+// SandboxResult.Skips use this type to distinguish between the top-level test that was run with
+// SandboxTest and subtests that were run within that test with TestingT.Run(). A nil value means the
+// top-level test; a single string element is the name of a subtest run from the top level with
+// TestingT.Run(); nested subtests add an element for each level.
+type TestPath []string
+
+// LogItem describes either a failed assertion or a skip that happened during SandboxTest.
+type LogItem struct {
+	// Path identifies the level of test that failed or was skipped.
+	Path TestPath
+
+	// Message is the failure message or skip message, if any. It is the result of calling fmt.Sprintf
+	// or Sprintln on the arguments that were passed to TestingT.Errorf or TestingT.Skip. If a test
+	// failed without specifying a message, this is "".
+	Message string
+}
+
+type mockTestingT struct {
+	testState
+	path TestPath
+	lock sync.Mutex
+}
+
+// SandboxTest runs a test function against a TestingT instance that applies only to the scope of
+// that test. If the function makes a failed assertion, marks the test as skipped, or forces an early
+// exit with FailNow or SkipNow, this is reflected in the SandboxResult but does not affect the state
+// of the regular test framework (assuming that this code is even executing within a Go test; it does
+// not have to be).
+//
+// The reason this uses a callback function parameter, rather than simply having the SandboxResult
+// implement TestingT itself, is that the function must be run on a separate goroutine so that
+// the sandbox can intercept any early exits from FailNow or SkipNow.
+//
+// SandboxTest does not recover from panics.
+//
+// See TestingT for more details.
+func SandboxTest(action func(TestingT)) SandboxResult {
+	sub := new(mockTestingT)
+	sub.runSafely(action)
+	state := sub.getState()
+	return SandboxResult{
+		Failed:   state.failed,
+		Skipped:  state.skipped,
+		Failures: state.failures,
+		Skips:    state.skips,
+	}
+}
+
+func (m *mockTestingT) Errorf(format string, args ...interface{}) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.failed = true
+	m.failures = append(m.failures, LogItem{Path: m.path, Message: fmt.Sprintf(format, args...)})
+}
+
+func (m *mockTestingT) Run(name string, action func(TestingT)) {
+	sub := &mockTestingT{path: append(m.path, name)}
+	sub.runSafely(action)
+	subState := sub.getState()
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.failed = m.failed || subState.failed
+	m.failures = append(m.failures, subState.failures...)
+	m.skips = append(m.skips, subState.skips...)
+}
+
+func (m *mockTestingT) FailNow() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.testState.failed = true
+	runtime.Goexit()
+}
+
+func (m *mockTestingT) Failed() bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.failed
+}
+
+func (m *mockTestingT) Skip(args ...interface{}) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.skipped = true
+	m.skips = append(m.skips, LogItem{Path: m.path, Message: strings.TrimSuffix(fmt.Sprintln(args...), "\n")})
+	runtime.Goexit()
+}
+
+func (m *mockTestingT) SkipNow() {
+	m.Skip()
+}
+
+func (m *mockTestingT) getState() testState {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	ret := testState{failed: m.failed, skipped: m.skipped}
+	if len(m.failures) > 0 {
+		ret.failures = make([]LogItem, len(m.failures))
+		copy(ret.failures, m.failures)
+	}
+	if len(m.skips) > 0 {
+		ret.skips = make([]LogItem, len(m.skips))
+		copy(ret.skips, m.skips)
+	}
+	return ret
+}
+
+func (m *mockTestingT) runSafely(action func(TestingT)) {
+	exited := make(chan struct{}, 1)
+	go func() {
+		defer func() {
+			close(exited)
+		}()
+		action(m)
+	}()
+	<-exited
+}

--- a/testbox/sandbox_test.go
+++ b/testbox/sandbox_test.go
@@ -1,0 +1,242 @@
+package testbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSandboxTest(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := SandboxTest(func(u TestingT) {
+			assert.True(u, true)
+		})
+
+		assert.False(t, r.Failed)
+		assert.Len(t, r.Failures, 0)
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		r := SandboxTest(func(u TestingT) {
+			assert.False(t, u.Failed())
+			assert.Equal(u, "abc", "def")
+			assert.Fail(u, "another message")
+			assert.True(t, u.Failed())
+		})
+
+		assert.True(t, r.Failed)
+		if assert.Len(t, r.Failures, 2) {
+			assert.Nil(t, r.Failures[0].Path)
+			assert.Contains(t, r.Failures[0].Message, "abc")
+			assert.Nil(t, r.Failures[1].Path)
+			assert.Contains(t, r.Failures[1].Message, "another")
+		}
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+	})
+
+	t.Run("FailNow", func(t *testing.T) {
+		continued := false
+
+		r := SandboxTest(func(u TestingT) {
+			u.FailNow()
+			continued = true
+		})
+
+		assert.True(t, r.Failed)
+		assert.Len(t, r.Failures, 0)
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+
+		assert.False(t, continued)
+	})
+
+	t.Run("skip", func(t *testing.T) {
+		ran := false
+		continued := false
+
+		r := SandboxTest(func(u TestingT) {
+			ran = true
+			u.Skip("please", "skip")
+			continued = true
+		})
+
+		assert.True(t, ran)
+		assert.False(t, continued)
+
+		assert.False(t, r.Failed)
+		assert.Len(t, r.Failures, 0)
+
+		assert.True(t, r.Skipped)
+		if assert.Len(t, r.Skips, 1) {
+			assert.Nil(t, r.Skips[0].Path)
+			assert.Equal(t, "please skip", r.Skips[0].Message)
+		}
+	})
+
+	t.Run("SkipNow", func(t *testing.T) {
+		ran := false
+		continued := false
+
+		r := SandboxTest(func(u TestingT) {
+			ran = true
+			u.SkipNow()
+			continued = true
+		})
+
+		assert.True(t, ran)
+		assert.False(t, continued)
+
+		assert.False(t, r.Failed)
+		assert.Len(t, r.Failures, 0)
+
+		assert.True(t, r.Skipped)
+		if assert.Len(t, r.Skips, 1) {
+			assert.Nil(t, r.Skips[0].Path)
+			assert.Equal(t, "", r.Skips[0].Message)
+		}
+	})
+}
+
+func TestSandboxTestSubtests(t *testing.T) {
+	t.Run("successes", func(t *testing.T) {
+		r := SandboxTest(func(u TestingT) {
+			u.Run("sub1", func(uu TestingT) {
+				assert.True(uu, true)
+			})
+			u.Run("sub2", func(uu TestingT) {
+				assert.True(uu, true)
+			})
+		})
+
+		assert.False(t, r.Failed)
+		assert.Len(t, r.Failures, 0)
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		r := SandboxTest(func(u TestingT) {
+			u.Run("sub1", func(uu TestingT) {
+				assert.Equal(uu, "abc", "def")
+			})
+			u.Run("sub2", func(uu TestingT) {
+				assert.Equal(uu, "ghi", "jkl")
+			})
+		})
+
+		assert.True(t, r.Failed)
+		if assert.Len(t, r.Failures, 2) {
+			assert.Equal(t, TestPath{"sub1"}, r.Failures[0].Path)
+			assert.Contains(t, r.Failures[0].Message, "abc")
+			assert.Equal(t, TestPath{"sub2"}, r.Failures[1].Path)
+			assert.Contains(t, r.Failures[1].Message, "ghi")
+		}
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+	})
+
+	t.Run("successes", func(t *testing.T) {
+		r := SandboxTest(func(u TestingT) {
+			u.Run("sub1", func(uu TestingT) {
+				assert.True(uu, true)
+			})
+			u.Run("sub2", func(uu TestingT) {
+				assert.True(uu, true)
+			})
+		})
+
+		assert.False(t, r.Failed)
+		assert.Len(t, r.Failures, 0)
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+	})
+
+	t.Run("FailNow", func(t *testing.T) {
+		continued1 := false
+		ran2 := false
+
+		r := SandboxTest(func(u TestingT) {
+			u.Run("sub1", func(uu TestingT) {
+				assert.True(uu, false)
+				uu.FailNow()           // equivalent to require.True(uu, false)
+				assert.False(uu, true) // we shouldn't get here
+				continued1 = true
+			})
+			u.Run("sub2", func(uu TestingT) {
+				ran2 = true
+			})
+		})
+
+		assert.False(t, continued1)
+		assert.True(t, ran2)
+
+		assert.True(t, r.Failed)
+		if assert.Len(t, r.Failures, 1) {
+			assert.Equal(t, TestPath{"sub1"}, r.Failures[0].Path)
+		}
+
+		assert.False(t, r.Skipped)
+		assert.Len(t, r.Skips, 0)
+	})
+
+	t.Run("skip", func(t *testing.T) {
+		continued1 := false
+		ran2 := false
+
+		r := SandboxTest(func(u TestingT) {
+			u.Run("sub1", func(uu TestingT) {
+				uu.Skip("please", "skip")
+				continued1 = true
+			})
+			u.Run("sub2", func(uu TestingT) {
+				ran2 = true
+			})
+		})
+
+		assert.False(t, continued1)
+		assert.True(t, ran2)
+
+		assert.False(t, r.Failed)
+
+		assert.False(t, r.Skipped)
+		if assert.Len(t, r.Skips, 1) {
+			assert.Equal(t, TestPath{"sub1"}, r.Skips[0].Path)
+			assert.Equal(t, "please skip", r.Skips[0].Message)
+		}
+	})
+
+	t.Run("SkipNow", func(t *testing.T) {
+		continued1 := false
+		ran2 := false
+
+		r := SandboxTest(func(u TestingT) {
+			u.Run("sub1", func(uu TestingT) {
+				uu.SkipNow()
+				continued1 = true // we shouldn't get here
+			})
+			u.Run("sub2", func(uu TestingT) {
+				ran2 = true
+			})
+		})
+
+		assert.False(t, continued1)
+		assert.True(t, ran2)
+
+		assert.False(t, r.Failed)
+
+		assert.False(t, r.Skipped)
+		if assert.Len(t, r.Skips, 1) {
+			assert.Equal(t, TestPath{"sub1"}, r.Skips[0].Path)
+			assert.Equal(t, "", r.Skips[0].Message)
+		}
+	})
+}


### PR DESCRIPTION
This is explained in the long doc comment in `interface.go`.

The current use case for this is in Go SDK 5.0, where we have a standard test suite that we run against every persistent data store implementation— basically contract tests. In order to verify that the standard test suite is reliable, we also run it against a reference implementation that's guaranteed to behave correctly. But we can't currently run it against a reference implementation that's guaranteed to behave _wrong_, without having a way to say "verify that this test fails, but don't actually fail".