### PR TITLE
ensure that stream handler starts response even if there's no data yet

### DIFF
--- a/httphelpers/handlers_streaming.go
+++ b/httphelpers/handlers_streaming.go
@@ -184,6 +184,8 @@ func (s *chunkedStreamingHandlerImpl) ServeHTTP(w http.ResponseWriter, r *http.R
 		flusher.Flush()
 	}
 
+	flusher.Flush()
+
 	var closeNotifyCh <-chan bool
 	// CloseNotifier is deprecated but there's no way to use Context in this case
 	if closeNotifier, ok := w.(http.CloseNotifier); ok { //nolint:megacheck


### PR DESCRIPTION
The lack of an initial `Flush()` meant that if you did _not_ specify any initial data for the stream, the client would hang waiting for a response. It should get a 200 response right away, and only block when it's trying to read the response body.