### PR TITLE
add some more test helpers for files & JSON

### DIFF
--- a/files.go
+++ b/files.go
@@ -22,7 +22,7 @@ func FilePathExists(path string) bool {
 //	helpers.WithTempFile(func(path string) {
 //		DoSomethingWithTempFile(path)
 //	}) // the file is deleted at the end of this block
-func WithTempFile(f func(string)) {
+func WithTempFile(f func(filePath string)) {
 	file, err := os.CreateTemp("", "test")
 	if err != nil {
 		panic(fmt.Errorf("can't create temp file: %s", err))
@@ -38,4 +38,25 @@ func WithTempFile(f func(string)) {
 		}
 	})()
 	f(file.Name())
+}
+
+// WithTempFileData is identical to WithTempFile except that it prepopulates the file with the
+// specified data.
+func WithTempFileData(data []byte, f func(filePath string)) {
+	WithTempFile(func(filePath string) {
+		if err := os.WriteFile(filePath, data, 0600); err != nil {
+			panic(fmt.Errorf("can't write to temp file: %s", err))
+		}
+		f(filePath)
+	})
+}
+
+// WithTempDir creates a temporary directory, calls the function with its path, then removes it.
+func WithTempDir(f func(path string)) {
+	path, err := os.MkdirTemp("", "test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(path) //nolint:errcheck
+	f(path)
 }

--- a/files_test.go
+++ b/files_test.go
@@ -1,9 +1,12 @@
 package helpers
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithTempFile(t *testing.T) {
@@ -13,4 +16,27 @@ func TestWithTempFile(t *testing.T) {
 		assert.True(t, FilePathExists(path))
 	})
 	assert.False(t, FilePathExists(filePath))
+}
+
+func TestWithTempFileData(t *testing.T) {
+	var filePath string
+	WithTempFileData([]byte(`hello`), func(path string) {
+		filePath = path
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(data))
+	})
+	assert.False(t, FilePathExists(filePath))
+}
+
+func TestWithTempDir(t *testing.T) {
+	var path string
+	WithTempDir(func(dirPath string) {
+		path = dirPath
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+		assert.NoError(t, os.WriteFile(filepath.Join(dirPath, "x"), []byte("hello"), 0600))
+	})
+	assert.False(t, FilePathExists(path))
 }

--- a/jsonhelpers/assertions.go
+++ b/jsonhelpers/assertions.go
@@ -1,0 +1,36 @@
+package jsonhelpers
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertEqual compares two JSON Value instances and returns true if they are deeply equal.
+// If they are not equal, it outputs a test failure message describing the mismatch as
+// specifically as possible.
+//
+// The two values may either be pre-parsed JValue instances, or if they are not, they are
+// converted using the same rules as JValueOf.
+func AssertEqual(t assert.TestingT, expected, actual any) bool {
+	ev, av := JValueOf(expected), JValueOf(actual)
+	if ev.err != nil {
+		t.Errorf("invalid expected value (%s): %s", ev.err, ev)
+		return false
+	}
+	if av.err != nil {
+		t.Errorf("invalid actual value (%s): %s", av.err, av)
+		return false
+	}
+	if reflect.DeepEqual(ev.parsed, av.parsed) {
+		return true
+	}
+	diff := describeValueDifference(ev.parsed, av.parsed, nil)
+	if len(diff) == 1 && diff[0].Path == nil {
+		t.Errorf("expected JSON value: %s\nactual value: %s", expected, actual)
+	} else {
+		t.Errorf("incorrect JSON value: %s\n"+strings.Join(diff.Describe("expected", "actual"), "\n"), actual)
+	}
+	return false
+}

--- a/jsonhelpers/assertions_test.go
+++ b/jsonhelpers/assertions_test.go
@@ -1,0 +1,41 @@
+package jsonhelpers
+
+import (
+	"testing"
+
+	"github.com/launchdarkly/go-test-helpers/v2/testbox"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertEqual(t *testing.T) {
+	AssertEqual(t, `{"a":true,"b":false}`, `{"b":false,"a":true}`)
+
+	AssertEqual(t, JValueOf(`{"a":true,"b":false}`), JValueOf(`{"b":false,"a":true}`))
+
+	result := testbox.SandboxTest(func(t testbox.TestingT) {
+		AssertEqual(t, `{"a":true,"b":false}`, `{"a":false,"b":false}`)
+	})
+	assert.True(t, result.Failed)
+	if assert.Len(t, result.Failures, 1) {
+		assert.Equal(t, `incorrect JSON value: {"a":false,"b":false}
+at "a": expected = true, actual = false`, result.Failures[0].Message)
+	}
+
+	result = testbox.SandboxTest(func(t testbox.TestingT) {
+		AssertEqual(t, `{"a":true,"b":false}`, `{`)
+	})
+	assert.True(t, result.Failed)
+	if assert.Len(t, result.Failures, 1) {
+		assert.Equal(t, `invalid actual value (JSON unmarshaling error: unexpected end of JSON input): {`,
+			result.Failures[0].Message)
+	}
+
+	result = testbox.SandboxTest(func(t testbox.TestingT) {
+		AssertEqual(t, `{`, `{"a":true,"b":false}`)
+	})
+	assert.True(t, result.Failed)
+	if assert.Len(t, result.Failures, 1) {
+		assert.Equal(t, `invalid expected value (JSON unmarshaling error: unexpected end of JSON input): {`,
+			result.Failures[0].Message)
+	}
+}

--- a/jsonhelpers/value.go
+++ b/jsonhelpers/value.go
@@ -1,0 +1,74 @@
+package jsonhelpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// JValue is a helper type for manipulating JSON data in tests. It validates that marshaled
+// data is valid JSON, allows other data to be converted to JSON, and eliminates ambiguity
+// as to whether a type like string or []byte in a test represents JSON or not.
+type JValue struct {
+	raw    string
+	parsed any
+	err    error
+}
+
+// String returns the JSON value as a string.
+func (v JValue) String() string {
+	return v.raw
+}
+
+// Error returns nil if the value is valid JSON, or else an error value describing the problem.
+func (v JValue) Error() error {
+	return v.err
+}
+
+// Equal returns true if the values are deeply equal.
+func (v JValue) Equal(v1 JValue) bool {
+	if v.err != nil || v1.err != nil {
+		return v.err == v1.err
+	}
+	return reflect.DeepEqual(v.parsed, v1.parsed)
+}
+
+// JValueOf creates a JValue based on any input type, as follows:
+//
+// - If the input type is []byte, json.RawMessage, or string, it interprets the value as JSON.
+// - If the input type is JValue, it returns the same value.
+// - For any other type, it attempts to marshal the value to JSON.
+//
+// If the input value is invalid, the returned JValue will have a non-nil Error().
+func JValueOf(value any) JValue {
+	var data []byte
+	switch v := value.(type) {
+	case JValue:
+		return v
+	case json.RawMessage:
+		data = v
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		d, err := json.Marshal(value)
+		if err != nil {
+			return JValue{
+				raw:    "<invalid>",
+				parsed: value,
+				err:    fmt.Errorf("value could not be marshalled to JSON: %s", err),
+			}
+		}
+		data = d
+	}
+	var intf interface{}
+	if err := json.Unmarshal(data, &intf); err != nil {
+		return JValue{
+			raw:    string(data),
+			parsed: nil,
+			err:    fmt.Errorf("JSON unmarshaling error: %s", err),
+		}
+	}
+	return JValue{raw: string(data), parsed: intf, err: nil}
+}

--- a/jsonhelpers/value_test.go
+++ b/jsonhelpers/value_test.go
@@ -1,0 +1,43 @@
+package jsonhelpers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJValueOf(t *testing.T) {
+	s := `{"a":true}`
+	m := map[string]interface{}{"a": true}
+
+	v1 := JValueOf([]byte(s))
+	assert.Nil(t, v1.Error())
+	assert.Equal(t, m, v1.parsed)
+	assert.Equal(t, s, v1.String())
+
+	v2 := JValueOf(json.RawMessage(s))
+	assert.Nil(t, v2.Error())
+	assert.Equal(t, m, v2.parsed)
+	assert.Equal(t, s, v2.String())
+	assert.Equal(t, v1, v2)
+
+	v3 := JValueOf(s)
+	assert.Nil(t, v3.Error())
+	assert.Equal(t, m, v3.parsed)
+	assert.Equal(t, s, v3.String())
+	assert.Equal(t, v1, v3)
+
+	v4 := JValueOf(m)
+	assert.Nil(t, v4.Error())
+	assert.Equal(t, m, v4.parsed)
+	assert.Equal(t, s, v4.String())
+	assert.Equal(t, v1, v4)
+
+	v5 := JValueOf(v4)
+	assert.Equal(t, v4, v5)
+
+	v6 := JValueOf("{no")
+	assert.NotNil(t, v6.Error())
+	assert.Equal(t, "{no", v6.String())
+}


### PR DESCRIPTION
Moving some more reusable logic out of the unit tests for go-server-sdk and other Go projects into this library. The new stuff in `jsonhelpers` is analogous to the JSON-related parts of `matchers`, but doesn't require the use of the `matchers` API in tests that wouldn't otherwise use it, and it's better than the ad-hoc JSON assertions we currently have in go-server-sdk.