### PR TITLE
call t.Helper() so our helpers don't mess up the stacktrace

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -29,6 +29,9 @@ func TryReceive[V any](ch <-chan V, timeout time.Duration) (V, bool, bool) {
 // RequireValue returns the next value from the channel, or forces an immediate test failure
 // and exit if the timeout expires first.
 func RequireValue[V any](t require.TestingT, ch <-chan V, timeout time.Duration, customMessageAndArgs ...any) V {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	v, ok, closed := TryReceive(ch, timeout)
 	if ok {
 		return v
@@ -53,6 +56,9 @@ func AssertNoMoreValues[V any](
 	timeout time.Duration,
 	customMessageAndArgs ...any,
 ) bool {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	v, ok, closed := TryReceive(ch, timeout)
 	if ok {
 		failWithMessageAndArgs(t, customMessageAndArgs,
@@ -73,6 +79,9 @@ func AssertChannelClosed[V any](
 	timeout time.Duration,
 	customMessageAndArgs ...any,
 ) bool {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	v, ok, closed := TryReceive(ch, timeout)
 	if ok {
 		failWithMessageAndArgs(t, customMessageAndArgs,
@@ -95,6 +104,9 @@ func AssertChannelNotClosed[V any](
 	timeout time.Duration,
 	customMessageAndArgs ...any,
 ) bool {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	for {

--- a/jsonhelpers/assertions.go
+++ b/jsonhelpers/assertions.go
@@ -14,6 +14,9 @@ import (
 // The two values may either be pre-parsed JValue instances, or if they are not, they are
 // converted using the same rules as JValueOf.
 func AssertEqual(t assert.TestingT, expected, actual any) bool {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	ev, av := JValueOf(expected), JValueOf(actual)
 	if ev.err != nil {
 		t.Errorf("invalid expected value (%s): %s", ev.err, ev)

--- a/testbox/sandbox.go
+++ b/testbox/sandbox.go
@@ -154,6 +154,9 @@ func (m *mockTestingT) runSafely(action func(TestingT)) {
 // ShouldFail is a shortcut for running some action against a testbox.TestingT and
 // asserting that it failed.
 func ShouldFail(t assert.TestingT, action func(TestingT)) bool {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	shouldGetHere := make(chan struct{}, 1)
 	result := SandboxTest(func(t1 TestingT) {
 		action(t1)
@@ -173,6 +176,9 @@ func ShouldFail(t assert.TestingT, action func(TestingT)) bool {
 // ShouldFailAndExitEarly is the same as ShouldFail, except that it also asserts that
 // the test was terminated early with FailNow.
 func ShouldFailAndExitEarly(t assert.TestingT, action func(TestingT)) bool {
+	if t, ok := t.(interface{ Helper() }); ok {
+		t.Helper()
+	}
 	shouldNotGetHere := make(chan struct{}, 1)
 	result := SandboxTest(func(t1 TestingT) {
 		action(t1)


### PR DESCRIPTION
I forgot that any test assertion helper that's going to call `t.Errorf()` should call `t.Helper()`, so that the stacktrace (on a test failure) will show the line that _called_ the helper, not the line where the helper called `Errorf`. This change doesn't affect whether tests pass or not, it just makes the failure output better.

Because these helpers are generalized to work with any type that fits a very general test context interface, `Helper()` might not always be available so we'll do an explicit check for it.